### PR TITLE
feat: add oxlint and oxfmt support

### DIFF
--- a/src/pillars/ci-cd.ts
+++ b/src/pillars/ci-cd.ts
@@ -118,7 +118,7 @@ const ciCd: Pillar = {
       id: "ci-runs-linters",
       name: "CI runs linters",
       description:
-        "The CI pipeline runs linting (eslint, biome, ruff, golangci-lint, or generic lint commands).",
+        "The CI pipeline runs linting or formatting checks (eslint, biome, oxlint, oxfmt, ruff, golangci-lint, or generic lint commands).",
       pillarId: "ci-cd",
       level: 3,
       requiresLLM: false,
@@ -133,7 +133,7 @@ const ciCd: Pillar = {
         }
 
         const lintPatterns =
-          /\b(npm\s+run\s+lint|yarn\s+lint|pnpm\s+lint|bun\s+run\s+lint|eslint|biome\s+check|biome\s+lint|ruff\s+check|ruff\s+lint|golangci-lint|make\s+lint|gradle\s+ktlintCheck|\.\/gradlew\s+ktlintCheck|gradle\s+detekt|\.\/gradlew\s+detekt|gradle\s+ktfmtCheck|\.\/gradlew\s+ktfmtCheck|\.\/gradlew\s+spotlessCheck|gradle\s+spotlessCheck|mvn\s+checkstyle|\.\/mvnw\s+checkstyle|mvn\s+pmd|cargo\s+clippy|cargo\s+fmt\s+--check|dotnet\s+format|rubocop|phpstan|psalm|phpcs|swiftlint)\b/i;
+          /\b(npm\s+run\s+lint|yarn\s+lint|pnpm\s+lint|bun\s+run\s+lint|eslint|biome\s+check|biome\s+lint|oxlint|oxfmt|ruff\s+check|ruff\s+lint|golangci-lint|make\s+lint|gradle\s+ktlintCheck|\.\/gradlew\s+ktlintCheck|gradle\s+detekt|\.\/gradlew\s+detekt|gradle\s+ktfmtCheck|\.\/gradlew\s+ktfmtCheck|\.\/gradlew\s+spotlessCheck|gradle\s+spotlessCheck|mvn\s+checkstyle|\.\/mvnw\s+checkstyle|mvn\s+pmd|cargo\s+clippy|cargo\s+fmt\s+--check|dotnet\s+format|rubocop|phpstan|psalm|phpcs|swiftlint)\b/i;
 
         for (const { file, content } of configs) {
           if (lintPatterns.test(content)) {

--- a/src/pillars/style-linting.ts
+++ b/src/pillars/style-linting.ts
@@ -25,6 +25,9 @@ const styleLinting: Pillar = {
           "eslint.config.*",
           "biome.json",
           "biome.jsonc",
+          ".oxlintrc.json",
+          ".oxlintrc.jsonc",
+          "oxlint.config.ts",
           ".ruff.toml",
           "ruff.toml",
           ".golangci.yml",
@@ -47,6 +50,29 @@ const styleLinting: Pillar = {
             pass: true,
             message: `Linter configuration found: ${found}`,
           };
+        }
+
+        // Check package.json for oxlint dependency or script usage, including custom --config paths.
+        const packageJsonLint = await readFileContent(repoPath, "package.json");
+        if (packageJsonLint) {
+          try {
+            const pkg = JSON.parse(packageJsonLint);
+            const scripts = Object.values(pkg.scripts ?? {}).join("\n");
+            const dependencies = {
+              ...pkg.dependencies,
+              ...pkg.devDependencies,
+              ...pkg.peerDependencies,
+            };
+            if (scripts.includes("oxlint") || dependencies.oxlint) {
+              return {
+                criterionId: "linter",
+                pass: true,
+                message: "oxlint found in package.json",
+              };
+            }
+          } catch {
+            // ignore parse errors
+          }
         }
 
         // Check for Kotlin/Java linters in build.gradle.kts or build.gradle
@@ -130,7 +156,7 @@ const styleLinting: Pillar = {
           pass: false,
           message: "No linter configuration found.",
           details:
-            "Add ESLint, Biome, Ruff, golangci-lint, detekt, ktlint, Checkstyle, clippy, StyleCop, RuboCop, PHPStan, or SwiftLint to enforce code quality.",
+            "Add ESLint, Biome, oxlint, Ruff, golangci-lint, detekt, ktlint, Checkstyle, clippy, StyleCop, RuboCop, PHPStan, or SwiftLint to enforce code quality.",
         };
       },
     },
@@ -156,6 +182,39 @@ const styleLinting: Pillar = {
             pass: true,
             message: `Formatter configuration found: ${prettierFound}`,
           };
+        }
+
+        // Check oxfmt
+        const oxfmtFound = await fileExists(repoPath, ".oxfmtrc.json", ".oxfmtrc.jsonc", "oxfmt.config.ts");
+        if (oxfmtFound) {
+          return {
+            criterionId: "formatter",
+            pass: true,
+            message: `oxfmt configuration found: ${oxfmtFound}`,
+          };
+        }
+
+        // Check package.json for oxfmt dependency or script usage, including custom --config paths.
+        const packageJsonFmt = await readFileContent(repoPath, "package.json");
+        if (packageJsonFmt) {
+          try {
+            const pkg = JSON.parse(packageJsonFmt);
+            const scripts = Object.values(pkg.scripts ?? {}).join("\n");
+            const dependencies = {
+              ...pkg.dependencies,
+              ...pkg.devDependencies,
+              ...pkg.peerDependencies,
+            };
+            if (scripts.includes("oxfmt") || dependencies.oxfmt) {
+              return {
+                criterionId: "formatter",
+                pass: true,
+                message: "oxfmt found in package.json",
+              };
+            }
+          } catch {
+            // ignore parse errors
+          }
         }
 
         // Check Biome with formatter
@@ -270,7 +329,7 @@ const styleLinting: Pillar = {
           pass: false,
           message: "No formatter configuration found.",
           details:
-            "Add Prettier, Biome, Black, Ruff, ktlint, ktfmt, Spotless, google-java-format, rustfmt, RuboCop, PHP-CS-Fixer, or SwiftFormat to enforce consistent code formatting.",
+            "Add Prettier, Biome, oxfmt, Black, Ruff, ktlint, ktfmt, Spotless, google-java-format, rustfmt, RuboCop, PHP-CS-Fixer, or SwiftFormat to enforce consistent code formatting.",
         };
       },
     },

--- a/tests/pillars/ci-cd.test.ts
+++ b/tests/pillars/ci-cd.test.ts
@@ -107,6 +107,22 @@ describe("ci-runs-linters", () => {
     expect(r.pass).toBe(true);
   });
 
+  test("js: oxlint", async () => {
+    const dir = await make("js-ci-oxlint", {
+      ".github/workflows/ci.yml": "jobs:\n  lint:\n    steps:\n      - run: oxlint src/",
+    });
+    const r = await ciRunsLintersCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: oxfmt --check", async () => {
+    const dir = await make("js-ci-oxfmt", {
+      ".github/workflows/ci.yml": "jobs:\n  lint:\n    steps:\n      - run: oxfmt --check src/",
+    });
+    const r = await ciRunsLintersCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("no CI fails", async () => {
     const dir = await make("ci-lint-empty");
     const r = await ciRunsLintersCheck(dir, mockProjectInfo());

--- a/tests/pillars/style-linting.test.ts
+++ b/tests/pillars/style-linting.test.ts
@@ -94,6 +94,33 @@ describe("linter", () => {
     expect(r.pass).toBe(true);
   });
 
+  // oxlint
+  test("js: .oxlintrc.json", async () => {
+    const dir = await make("js-lint-oxlint", { ".oxlintrc.json": '{"rules":{}}' });
+    const r = await linterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: .oxlintrc.jsonc", async () => {
+    const dir = await make("js-lint-oxlint-jsonc", { ".oxlintrc.jsonc": "// oxlint config\n{}" });
+    const r = await linterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: oxlint.config.ts", async () => {
+    const dir = await make("js-lint-oxlint-config-ts", { "oxlint.config.ts": "export default {};" });
+    const r = await linterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: oxlint in package.json script", async () => {
+    const dir = await make("js-lint-oxlint-package", {
+      "package.json": '{"scripts":{"lint":"oxlint --config ./config/oxlint.json src"}}',
+    });
+    const r = await linterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
   // Fail case
   test("empty dir fails", async () => {
     const dir = await make("lint-empty");
@@ -137,6 +164,33 @@ describe("formatter", () => {
   test("swift: .swiftformat", async () => {
     const dir = await make("swift-fmt", { ".swiftformat": "--indent 4" });
     const r = await formatterCheck(dir, mockProjectInfo({ detectedTypes: ["swift"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  // oxfmt
+  test("js: .oxfmtrc.json", async () => {
+    const dir = await make("js-fmt-oxfmt", { ".oxfmtrc.json": '{"printWidth":80}' });
+    const r = await formatterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: .oxfmtrc.jsonc", async () => {
+    const dir = await make("js-fmt-oxfmt-jsonc", { ".oxfmtrc.jsonc": "// oxfmt config\n{}" });
+    const r = await formatterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: oxfmt.config.ts", async () => {
+    const dir = await make("js-fmt-oxfmt-config-ts", { "oxfmt.config.ts": "export default {};" });
+    const r = await formatterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("js: oxfmt in package.json script", async () => {
+    const dir = await make("js-fmt-oxfmt-package", {
+      "package.json": '{"scripts":{"format:check":"oxfmt --check --config ./config/oxfmt.json src"}}',
+    });
+    const r = await formatterCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
     expect(r.pass).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Add oxlint detection to the Style & Linting audit via supported config files and package.json usage.
- Add oxfmt detection to the Formatter audit via supported config files and package.json usage.
- Recognize oxlint and oxfmt style checks in CI workflow detection.

## Supported scenarios
- oxlint config files: `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`
- oxfmt config files: `.oxfmtrc.json`, `.oxfmtrc.jsonc`, `oxfmt.config.ts`
- package.json scripts and dependencies using `oxlint` or `oxfmt`, including custom `--config` paths
- CI commands that run `oxlint` or `oxfmt --check`

## Validation
- `bun test`
- `bun run typecheck`
- `bun run build`