### PR TITLE
feat: add Bun runtime detection

### DIFF
--- a/src/pillars/code-health.ts
+++ b/src/pillars/code-health.ts
@@ -28,6 +28,7 @@ const codeHealth: Pillar = {
         // Check all common lock/build files for freshness
         const lockFiles = [
           "package-lock.json",
+          "bun.lock",
           "bun.lockb",
           "yarn.lock",
           "pnpm-lock.yaml",

--- a/src/pillars/dev-environment.ts
+++ b/src/pillars/dev-environment.ts
@@ -25,6 +25,7 @@ const devEnvironment: Pillar = {
         const found = await fileExists(
           repoPath,
           "package-lock.json",
+          "bun.lock",
           "bun.lockb",
           "yarn.lock",
           "pnpm-lock.yaml",
@@ -248,6 +249,30 @@ const devEnvironment: Pillar = {
             message: `Version pinning found: ${found}`,
           };
         }
+
+        const packageJson = await readFileContent(repoPath, "package.json");
+        if (packageJson) {
+          try {
+            const pkg = JSON.parse(packageJson);
+            if (typeof pkg.packageManager === "string" && pkg.packageManager.startsWith("bun@")) {
+              return {
+                criterionId: "version-pinned",
+                pass: true,
+                message: "Bun version pinned in package.json packageManager",
+              };
+            }
+            if (typeof pkg.engines?.bun === "string") {
+              return {
+                criterionId: "version-pinned",
+                pass: true,
+                message: "Bun version declared in package.json engines.bun",
+              };
+            }
+          } catch {
+            // ignore parse errors
+          }
+        }
+
         return {
           criterionId: "version-pinned",
           pass: false,

--- a/tests/pillars/code-health.test.ts
+++ b/tests/pillars/code-health.test.ts
@@ -31,6 +31,12 @@ const deadCodeCheck = getCheck(codeHealth, "dead-code-detection");
 // no-outdated-deps — new lock files recognized
 // ---------------------------------------------------------------------------
 describe("no-outdated-deps", () => {
+  test("node: bun.lock (fresh)", async () => {
+    const dir = await make("node-bun-fresh", { "bun.lock": "{}" });
+    const r = await freshnessCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("csharp: packages.lock.json (fresh)", async () => {
     const dir = await make("cs-fresh", { "packages.lock.json": "{}" });
     const r = await freshnessCheck(dir, mockProjectInfo({ detectedTypes: ["csharp"] }));

--- a/tests/pillars/dev-environment.test.ts
+++ b/tests/pillars/dev-environment.test.ts
@@ -32,6 +32,12 @@ const setupScriptCheck = getCheck(devEnvironment, "setup-script");
 // lock-file
 // ---------------------------------------------------------------------------
 describe("lock-file", () => {
+  test("node: bun.lock", async () => {
+    const dir = await make("node-bun-lock", { "bun.lock": "{}" });
+    const r = await lockFileCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("csharp: packages.lock.json", async () => {
     const dir = await make("cs-lock", { "packages.lock.json": "{}" });
     const r = await lockFileCheck(dir, mockProjectInfo({ detectedTypes: ["csharp"] }));
@@ -67,6 +73,22 @@ describe("lock-file", () => {
 // version-pinned
 // ---------------------------------------------------------------------------
 describe("version-pinned", () => {
+  test("node: packageManager pins bun", async () => {
+    const dir = await make("node-bun-package-manager", {
+      "package.json": '{"packageManager":"bun@1.2.20"}',
+    });
+    const r = await versionPinnedCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
+  test("node: engines.bun declares bun version", async () => {
+    const dir = await make("node-bun-engines", {
+      "package.json": '{"engines":{"bun":">=1.2.0"}}',
+    });
+    const r = await versionPinnedCheck(dir, mockProjectInfo({ detectedTypes: ["node"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("ruby: .ruby-version", async () => {
     const dir = await make("rb-ver", { ".ruby-version": "3.2.2" });
     const r = await versionPinnedCheck(dir, mockProjectInfo({ detectedTypes: ["ruby"] }));


### PR DESCRIPTION
## Summary
- Recognize Bun's text lockfile `bun.lock` in developer environment lock-file audits.
- Include `bun.lock` in dependency freshness checks.
- Detect Bun runtime version pinning from `package.json` via `packageManager: "bun@..."` and `engines.bun`.

## Validation
- `bun test`
- `bun run typecheck`
- `bun run build`