### PR TITLE
fix: recognize uv.lock files

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Without `--ai`, AI-powered criteria are **skipped** (not counted as failures).
 
 | Criterion | Level | AI | What It Detects |
 |---|---|---|---|
-| `lock-file` | 1 | No | package-lock.json, bun.lockb, yarn.lock, go.sum, Cargo.lock, gradle.lockfile, packages.lock.json, Gemfile.lock, composer.lock, Package.resolved |
+| `lock-file` | 1 | No | package-lock.json, bun.lockb, yarn.lock, uv.lock, go.sum, Cargo.lock, gradle.lockfile, packages.lock.json, Gemfile.lock, composer.lock, Package.resolved |
 | `env-documentation` | 2 | No | .env.example, .env.template |
 | `setup-script` | 2 | No | Makefile targets, setup scripts, `dev` script, Gradle wrapper, Maven wrapper, .sln (dotnet), Rakefile |
 | `version-pinned` | 2 | No | .nvmrc, .python-version, .tool-versions, mise.toml, .sdkmanrc, .java-version, rust-toolchain.toml, .ruby-version, .php-version, .swift-version, global.json |
@@ -441,7 +441,7 @@ Without `--ai`, AI-powered criteria are **skipped** (not counted as failures).
 
 | Criterion | Level | AI | What It Detects |
 |---|---|---|---|
-| `no-outdated-deps` | 3 | No | Lock file freshness across all languages (npm, yarn, pnpm, bun, Gradle, Poetry, Pipfile, go.sum, Cargo.lock, packages.lock.json, Gemfile.lock, composer.lock, Package.resolved) |
+| `no-outdated-deps` | 3 | No | Lock file freshness across all languages (npm, yarn, pnpm, bun, uv, Gradle, Poetry, Pipfile, go.sum, Cargo.lock, packages.lock.json, Gemfile.lock, composer.lock, Package.resolved) |
 | `dead-code-detection` | 4 | No | Knip, unused-exports ESLint plugin, detekt, vulture (Python), cargo-udeps (Rust), SpotBugs/FindBugs (Java), Roslynator (C#), debride/reek (Ruby), PHPMD (PHP) |
 | `bundle-analysis` | 5 | No | webpack-bundle-analyzer, @next/bundle-analyzer, size-limit |
 

--- a/src/engine/recommender.ts
+++ b/src/engine/recommender.ts
@@ -120,7 +120,7 @@ const CRITERION_INFO: Record<
   // Dev Environment
   "lock-file": {
     description:
-      "Commit a dependency lock file (package-lock.json, bun.lockb, yarn.lock, poetry.lock, etc.)",
+      "Commit a dependency lock file (package-lock.json, bun.lockb, uv.lock, yarn.lock, poetry.lock, etc.)",
     reason:
       "Lock files ensure agents install the exact same dependency versions, preventing 'works on my machine' issues",
   },

--- a/src/pillars/code-health.ts
+++ b/src/pillars/code-health.ts
@@ -31,6 +31,7 @@ const codeHealth: Pillar = {
           "bun.lockb",
           "yarn.lock",
           "pnpm-lock.yaml",
+          "uv.lock",
           "gradle.lockfile",
           "build.gradle.kts",
           "build.gradle",

--- a/src/pillars/dev-environment.ts
+++ b/src/pillars/dev-environment.ts
@@ -17,7 +17,7 @@ const devEnvironment: Pillar = {
       id: "lock-file",
       name: "Lock file present",
       description:
-        "A dependency lock file exists (package-lock.json, yarn.lock, pnpm-lock.yaml, go.sum, etc.).",
+        "A dependency lock file exists (package-lock.json, uv.lock, yarn.lock, pnpm-lock.yaml, go.sum, etc.).",
       pillarId: "dev-environment",
       level: 1,
       requiresLLM: false,
@@ -28,6 +28,7 @@ const devEnvironment: Pillar = {
           "bun.lockb",
           "yarn.lock",
           "pnpm-lock.yaml",
+          "uv.lock",
           "poetry.lock",
           "Pipfile.lock",
           "go.sum",

--- a/tests/pillars/code-health.test.ts
+++ b/tests/pillars/code-health.test.ts
@@ -31,6 +31,12 @@ const deadCodeCheck = getCheck(codeHealth, "dead-code-detection");
 // no-outdated-deps — new lock files recognized
 // ---------------------------------------------------------------------------
 describe("no-outdated-deps", () => {
+  test("python: uv.lock (fresh)", async () => {
+    const dir = await make("uv-fresh", { "uv.lock": "" });
+    const r = await freshnessCheck(dir, mockProjectInfo({ detectedTypes: ["python"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("csharp: packages.lock.json (fresh)", async () => {
     const dir = await make("cs-fresh", { "packages.lock.json": "{}" });
     const r = await freshnessCheck(dir, mockProjectInfo({ detectedTypes: ["csharp"] }));

--- a/tests/pillars/dev-environment.test.ts
+++ b/tests/pillars/dev-environment.test.ts
@@ -32,6 +32,12 @@ const setupScriptCheck = getCheck(devEnvironment, "setup-script");
 // lock-file
 // ---------------------------------------------------------------------------
 describe("lock-file", () => {
+  test("python: uv.lock", async () => {
+    const dir = await make("uv-lock", { "uv.lock": "" });
+    const r = await lockFileCheck(dir, mockProjectInfo({ detectedTypes: ["python"] }));
+    expect(r.pass).toBe(true);
+  });
+
   test("csharp: packages.lock.json", async () => {
     const dir = await make("cs-lock", { "packages.lock.json": "{}" });
     const r = await lockFileCheck(dir, mockProjectInfo({ detectedTypes: ["csharp"] }));


### PR DESCRIPTION
## Summary
  - recognize uv.lock as a dependency lock file
  - include uv.lock in dependency freshness checks
  - update docs and recommendations
  - add regression tests for uv.lock

  ## Tests
  - bun test
  - bun run typecheck
  - bun run build
  - bun run lint

Fixes #6 